### PR TITLE
Swift 4 compatibility updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ build
 /.build
 /Packages
 /*.xcodeproj
+Package.resolved
+

--- a/Package.swift
+++ b/Package.swift
@@ -30,12 +30,15 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", from: "1.0.0"),
-        .package(url: "https://github.com/NocturnalSolutions/CSQLite.git", from: "0.2.0")
     ],
     targets: [
         .target(
             name: "SwiftKuerySQLite",
-            dependencies: ["SwiftKuery"]
+            dependencies: ["SwiftKuery", "CSQLite"]
+        ),
+        .target(
+            name: "CSQLite",
+            dependencies: []
         ),
         .testTarget(
             name: "SwiftKuerySQLiteTests",

--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,6 @@
+// swift-tools-version:4.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
 /**
  * Copyright IBM Corporation 2016, 2017
  *
@@ -19,11 +22,24 @@ import PackageDescription
 
 let package = Package(
     name: "SwiftKuerySQLite",
-    targets: [Target(name: "SwiftKuerySQLite", dependencies: [.Target(name: "CSQLite")]),
-              Target(name: "CSQLite")
+    products: [
+        .library(
+            name: "SwiftKuerySQLite",
+            targets: ["SwiftKuerySQLite"]
+        )
     ],
     dependencies: [
-        .Package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", majorVersion: 0, minor: 13),
-        ],
-    exclude: ["Configuration", "Scripts"]
+        .package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", from: "1.0.0"),
+        .package(url: "https://github.com/NocturnalSolutions/CSQLite.git", from: "0.2.0")
+    ],
+    targets: [
+        .target(
+            name: "SwiftKuerySQLite",
+            dependencies: ["SwiftKuery"]
+        ),
+        .testTarget(
+            name: "SwiftKuerySQLiteTests",
+            dependencies: ["SwiftKuerySQLite"]
+        )
+    ]
 )

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Swift-Kuery-SQLite
 
-🚫 This project is no longer maintained.
-
 SQLite plugin for the [Swift-Kuery](https://github.com/IBM-Swift/Swift-Kuery) framework.
 
-[![Build Status - Master](https://travis-ci.org/IBM-Swift/Kitura.svg?branch=master)](https://travis-ci.org/IBM-Swift/Swift-Kuery-SQLite)
+This is a fork of the [original project](https://github.com/IBM-Swift-Sunset/Swift-Kuery-SQLite), which was ”sunsetted“ rather than being ported to Swift 4. But I have updated it for Swift 4, so… I guess I'm maintaining it now?
+
+<!-- [![Build Status - Master](https://travis-ci.org/IBM-Swift/Kitura.svg?branch=master)](https://travis-ci.org/IBM-Swift/Swift-Kuery-SQLite) /-->
 ![macOS](https://img.shields.io/badge/os-macOS-green.svg?style=flat)
 ![Linux](https://img.shields.io/badge/os-linux-green.svg?style=flat)
 ![Apache 2](https://img.shields.io/badge/license-Apache2-blue.svg?style=flat)
@@ -17,8 +17,19 @@ SQLite plugin for the [Swift-Kuery](https://github.com/IBM-Swift/Swift-Kuery) fr
 To use Swift-Kuery-SQLite you must install SQLite.
 
 ### macOS
+
+With Homebrew:
+
 ```
 $ brew install sqlite
+```
+
+Or, if you prefer MacPorts, you can use that too, though note that you need to symlink a file into the place that Homebrew installs it:
+
+```
+$ port install sqlite3
+$ mkdir -p /usr/local/opt/sqlite/include
+$ ln -s /opt/local/include/sqlite3.h /usr/local/opt/sqlite/include/
 ```
 
 ### Linux

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # Swift-Kuery-SQLite
 
-SQLite plugin for the [Swift-Kuery](https://github.com/IBM-Swift/Swift-Kuery) framework.
+[SQLite](https://sqlite.org/) plugin for the [Swift-Kuery](https://github.com/IBM-Swift/Swift-Kuery) framework.
 
-This is a fork of the [original project](https://github.com/IBM-Swift-Sunset/Swift-Kuery-SQLite), which was ”sunsetted“ rather than being ported to Swift 4. But I have updated it for Swift 4, so… I guess I'm maintaining it now?
-
-<!-- [![Build Status - Master](https://travis-ci.org/IBM-Swift/Kitura.svg?branch=master)](https://travis-ci.org/IBM-Swift/Swift-Kuery-SQLite) /-->
+[![Build Status - Master](https://travis-ci.org/IBM-Swift/Kitura.svg?branch=master)](https://travis-ci.org/IBM-Swift/Swift-Kuery-SQLite)
 ![macOS](https://img.shields.io/badge/os-macOS-green.svg?style=flat)
 ![Linux](https://img.shields.io/badge/os-linux-green.svg?style=flat)
 ![Apache 2](https://img.shields.io/badge/license-Apache2-blue.svg?style=flat)
@@ -51,7 +49,7 @@ To establish a connection call:
 db.connect(onCompletion: (QueryError?) -> ())
 ```
 
-You now have a connection that can be used to execute SQL queries created using Swift-Kuery. View the [Kuery](https://github.com/IBM-Swift/Swift-Kuery) documentation for more information.
+You now have a connection that can be used to execute SQL queries created using Swift-Kuery. View the [Kuery](https://github.com/IBM-Swift/Swift-Kuery) documentation for more information, or see the [Database Connectivity with Kuery](https://nocturnalsolutions.gitbooks.io/kitura-book/content/5-kuery.html) chapter of the *[Kitura Until Dawn](https://www.gitbook.com/book/nocturnalsolutions/kitura-book)* guidebook/tutorial.
 
 ## License
 This library is licensed under Apache 2.0. Full license text is available in [LICENSE](LICENSE.txt).

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To use Swift-Kuery-SQLite you must install SQLite.
 
 ### macOS
 
-With Homebrew:
+You can install SQLite with Homebrew:
 
 ```
 $ brew install sqlite

--- a/Sources/SwiftKuerySQLite/SQLiteConnection.swift
+++ b/Sources/SwiftKuerySQLite/SQLiteConnection.swift
@@ -62,8 +62,13 @@ public class SQLiteConnection: Connection {
                 QueryBuilder.QuerySubstitutionNames.len : "LENGTH",
                 // Note: SQLite's DATETIME() seems to always return UTC results,
                 // whereas MySQL's NOW() will return local (system) time by de-
-                // fault unless configured to use a specific timezone.
-                QueryBuilder.QuerySubstitutionNames.now : "DATETIME()",
+                // fault unless configured to use a specific timezone. Also, we
+                // concatcenate " +0000" to the end of the generated formatted
+                // time string since Date objects will be formatted with these
+                // offsets as well and SQLite will consider
+                // "2018-03-11 05:24:15" to be "smaller" than
+                // "2018-03-11 05:24:15 +0000".
+                QueryBuilder.QuerySubstitutionNames.now : "DATETIME() || ' +0000'",
                 QueryBuilder.QuerySubstitutionNames.all : "",
                 QueryBuilder.QuerySubstitutionNames.booleanTrue : "1",
                 QueryBuilder.QuerySubstitutionNames.booleanFalse : "0"])

--- a/Sources/SwiftKuerySQLite/SQLiteConnection.swift
+++ b/Sources/SwiftKuerySQLite/SQLiteConnection.swift
@@ -60,7 +60,10 @@ public class SQLiteConnection: Connection {
                 QueryBuilder.QuerySubstitutionNames.ucase : "UPPER",
                 QueryBuilder.QuerySubstitutionNames.lcase : "LOWER",
                 QueryBuilder.QuerySubstitutionNames.len : "LENGTH",
-                QueryBuilder.QuerySubstitutionNames.now : "'now'",
+                // Note: SQLite's DATETIME() seems to always return UTC results,
+                // whereas MySQL's NOW() will return local (system) time by de-
+                // fault unless configured to use a specific timezone.
+                QueryBuilder.QuerySubstitutionNames.now : "DATETIME()",
                 QueryBuilder.QuerySubstitutionNames.all : "",
                 QueryBuilder.QuerySubstitutionNames.booleanTrue : "1",
                 QueryBuilder.QuerySubstitutionNames.booleanFalse : "0"])

--- a/Tests/SwiftKuerySQLiteTests/Test.swift
+++ b/Tests/SwiftKuerySQLiteTests/Test.swift
@@ -33,7 +33,7 @@ extension Test {
         // sleep(10)
     }
 
-    func performTest(asyncTasks: @escaping (XCTestExpectation) -> Void...) {
+    func performTest(asyncTasks: (XCTestExpectation) -> Void...) {
         let queue = DispatchQueue(label: "Query queue")
 
         for (index, asyncTask) in asyncTasks.enumerated() {

--- a/Tests/SwiftKuerySQLiteTests/TestSelect.swift
+++ b/Tests/SwiftKuerySQLiteTests/TestSelect.swift
@@ -343,7 +343,7 @@ class TestSelect: XCTestCase {
                                     XCTAssertEqual(rows!.count, 1, "SELECT returned wrong number of rows: \(rows!.count) instead of 1")
                                     
                                     let s3 = Select(from: t)
-                                        .where(now() > t.date)
+                                        .where(now() >= t.date)
                                     executeQuery(query: s3, connection: connection) { result, rows in
                                         XCTAssertEqual(result.success, true, "SELECT failed")
                                         XCTAssertNotNil(result.asResultSet, "SELECT returned no rows")

--- a/Tests/SwiftKuerySQLiteTests/VerifyLinuxTestCount.swift
+++ b/Tests/SwiftKuerySQLiteTests/VerifyLinuxTestCount.swift
@@ -23,43 +23,43 @@
             var darwinCount: Int = 0
             
             linuxCount = TestAlias.allTests.count
-            darwinCount = Int(TestAlias.defaultTestSuite().testCaseCount)
+            darwinCount = Int(TestAlias.defaultTestSuite.testCaseCount)
             XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestAlias.allTests")
 
             linuxCount = TestInsert.allTests.count
-            darwinCount = Int(TestInsert.defaultTestSuite().testCaseCount)
+            darwinCount = Int(TestInsert.defaultTestSuite.testCaseCount)
             XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestInsert.allTests")
 
             linuxCount = TestJoin.allTests.count
-            darwinCount = Int(TestJoin.defaultTestSuite().testCaseCount)
+            darwinCount = Int(TestJoin.defaultTestSuite.testCaseCount)
             XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestJoin.allTests")
 
             linuxCount = TestParameters.allTests.count
-            darwinCount = Int(TestParameters.defaultTestSuite().testCaseCount)
+            darwinCount = Int(TestParameters.defaultTestSuite.testCaseCount)
             XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestParameters.allTests")
 
             linuxCount = TestSchema.allTests.count
-            darwinCount = Int(TestSchema.defaultTestSuite().testCaseCount)
+            darwinCount = Int(TestSchema.defaultTestSuite.testCaseCount)
             XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestSchema.allTests")
 
             linuxCount = TestSelect.allTests.count
-            darwinCount = Int(TestSelect.defaultTestSuite().testCaseCount)
+            darwinCount = Int(TestSelect.defaultTestSuite.testCaseCount)
             XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestSelect.allTests")
 
             linuxCount = TestSubquery.allTests.count
-            darwinCount = Int(TestSubquery.defaultTestSuite().testCaseCount)
+            darwinCount = Int(TestSubquery.defaultTestSuite.testCaseCount)
             XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestSubquery.allTests")
 
             linuxCount = TestTransaction.allTests.count
-            darwinCount = Int(TestTransaction.defaultTestSuite().testCaseCount)
+            darwinCount = Int(TestTransaction.defaultTestSuite.testCaseCount)
             XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestTransaction.allTests")
 
             linuxCount = TestUpdate.allTests.count
-            darwinCount = Int(TestUpdate.defaultTestSuite().testCaseCount)
+            darwinCount = Int(TestUpdate.defaultTestSuite.testCaseCount)
             XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestUpdate.allTests")
 
             linuxCount = TestWith.allTests.count
-            darwinCount = Int(TestWith.defaultTestSuite().testCaseCount)
+            darwinCount = Int(TestWith.defaultTestSuite.testCaseCount)
             XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestWith.allTests")
         }
     }


### PR DESCRIPTION
In December, I forked this repo and updated it for Swift 4 compatibility so I could use it both for my own projects and so I could [instruct people how to use Kuery](https://nocturnalsolutions.gitbooks.io/kitura-book/content/5-kuery.html) without them having to install and configure a full RDBMS server first.

Today, @enriquel8 told me via the Swift@IBM Slack system that you folks intend to start maintaining this again and asked me to create a PR with my changes. So here it is.

Aside from the Swift 4 updates (mostly via Xcode's automated tool, though IIRC the Package.swift updates had to be done manually), there's a couple more changes here:

* Package.resolved has been added to .gitignore. I'm 83% sure (plus or minus 20%) this is a best practice for libraries, even though `swift package init --type=library` doesn't do it automatically.
* I've added a blurb about taking over maintenance of the package to README.md. This would need to be removed.
* `QueryBuilder.QuerySubstitutionNames.now` is set to `DATETIME()` rather than `'now'`. I'm not sure how a string of "now" would accomplish what was intended here, especially given SQLite's loosey-goosey typing.