### PR TITLE
Added Int32 type support when binding parameter

### DIFF
--- a/Sources/SwiftKuerySQLite/SQLiteConnection.swift
+++ b/Sources/SwiftKuerySQLite/SQLiteConnection.swift
@@ -360,6 +360,8 @@ public class SQLiteConnection: Connection {
                 resultCode = sqlite3_bind_double(statement, index, Double(value))
             case let value as Double:
                 resultCode = sqlite3_bind_double(statement, index, value)
+            case let value as  Int32:
+                resultCode = sqlite3_bind_int(statement, index, value)
             case let value as Int:
                 resultCode = sqlite3_bind_int64(statement, index, Int64(value))
             case let value as Data:

--- a/Sources/SwiftKuerySQLite/SQLiteConnection.swift
+++ b/Sources/SwiftKuerySQLite/SQLiteConnection.swift
@@ -360,7 +360,7 @@ public class SQLiteConnection: Connection {
                 resultCode = sqlite3_bind_double(statement, index, Double(value))
             case let value as Double:
                 resultCode = sqlite3_bind_double(statement, index, value)
-            case let value as  Int32:
+            case let value as Int32:
                 resultCode = sqlite3_bind_int(statement, index, value)
             case let value as Int:
                 resultCode = sqlite3_bind_int64(statement, index, Int64(value))


### PR DESCRIPTION
This commit resolve an “Unsupported type error” when a query contains an Int32 bindend parameter