### PR TITLE
Add AUTO INCREMENT support for SQLite

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", from: "1.0.0"),
+        .package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", from: "2.0.0"),
     ],
     targets: [
         .target(

--- a/Sources/SwiftKuerySQLite/SQLiteConnection.swift
+++ b/Sources/SwiftKuerySQLite/SQLiteConnection.swift
@@ -54,7 +54,7 @@ public class SQLiteConnection: Connection {
     /// - Returns: An instance of `SQLiteConnection`.
     public init(_ location: Location = .inMemory) {
         self.location = location
-        self.queryBuilder = QueryBuilder(anyOnSubquerySupported: false)
+        self.queryBuilder = QueryBuilder(anyOnSubquerySupported: false, createAutoIncrement: SQLiteConnection.createAutoIncrement)
         queryBuilder.updateSubstitutions(
             [
                 QueryBuilder.QuerySubstitutionNames.ucase : "UPPER",
@@ -72,6 +72,14 @@ public class SQLiteConnection: Connection {
                 QueryBuilder.QuerySubstitutionNames.all : "",
                 QueryBuilder.QuerySubstitutionNames.booleanTrue : "1",
                 QueryBuilder.QuerySubstitutionNames.booleanFalse : "0"])
+    }
+
+    static func createAutoIncrement(_ type: String, _ primaryKey: Bool) -> String {
+        if primaryKey && type == "integer" {
+            return type + "AUTOINCREMENT"
+        } else {
+            return ""
+        }
     }
     
     /// Initialiser with a path to where the database is stored.

--- a/Tests/SwiftKuerySQLiteTests/CommonUtils.swift
+++ b/Tests/SwiftKuerySQLiteTests/CommonUtils.swift
@@ -101,7 +101,7 @@ func executeRawQuery(_ raw: String, connection: Connection, callback: @escaping 
 }
 
 func cleanUp(table: String, connection: Connection, callback: @escaping (QueryResult)->()) {
-    connection.execute("DROP TABLE " + table) { result in
+    connection.execute("DROP TABLE \"" + table + "\"") { result in
         callback(result)
     }
 }

--- a/Tests/SwiftKuerySQLiteTests/TestAlias.swift
+++ b/Tests/SwiftKuerySQLiteTests/TestAlias.swift
@@ -53,7 +53,7 @@ class TestAlias: XCTestCase {
             
             cleanUp(table: t.tableName, connection: connection) { result in
                 
-                executeRawQuery("CREATE TABLE " +  t.tableName + " (a varchar(40), b integer)", connection: connection) { result, rows in
+                executeRawQuery("CREATE TABLE \"" +  t.tableName + "\" (a varchar(40), b integer)", connection: connection) { result, rows in
                     XCTAssertEqual(result.success, true, "CREATE TABLE failed")
                     XCTAssertNil(result.asError, "Error in CREATE TABLE: \(result.asError!)")
                     

--- a/Tests/SwiftKuerySQLiteTests/TestInsert.swift
+++ b/Tests/SwiftKuerySQLiteTests/TestInsert.swift
@@ -63,11 +63,11 @@ class TestInsert: XCTestCase {
             cleanUp(table: t.tableName, connection: connection) { result in
                 cleanUp(table: t2.tableName, connection: connection) { result in
                     
-                    executeRawQuery("CREATE TABLE " +  t.tableName + " (a varchar(40), b integer)", connection: connection) { result, rows in
+                    executeRawQuery("CREATE TABLE \"" +  t.tableName + "\" (a varchar(40), b integer)", connection: connection) { result, rows in
                         XCTAssertEqual(result.success, true, "CREATE TABLE failed")
                         XCTAssertNil(result.asError, "Error in CREATE TABLE: \(result.asError!)")
                         
-                        executeRawQuery("CREATE TABLE " +  t2.tableName + " (a varchar(40), b integer)", connection: connection) { result, rows in
+                        executeRawQuery("CREATE TABLE \"" +  t2.tableName + "\" (a varchar(40), b integer)", connection: connection) { result, rows in
                             XCTAssertEqual(result.success, true, "CREATE TABLE failed")
                             XCTAssertNil(result.asError, "Error in CREATE TABLE: \(result.asError!)")
                             

--- a/Tests/SwiftKuerySQLiteTests/TestJoin.swift
+++ b/Tests/SwiftKuerySQLiteTests/TestJoin.swift
@@ -78,16 +78,16 @@ class TestJoin: XCTestCase {
                     
                     cleanUp(table: myTable3.tableName, connection: connection) { result in
                         
-                        executeRawQuery("CREATE TABLE " +  myTable1.tableName + " (a varchar(40), b integer)", connection: connection) { result, rows in
+                        executeRawQuery("CREATE TABLE \"" +  myTable1.tableName + "\" (a varchar(40), b integer)", connection: connection) { result, rows in
                             
                             XCTAssertEqual(result.success, true, "CREATE TABLE failed")
                             XCTAssertNil(result.asError, "Error in CREATE TABLE: \(result.asError!)")
                             
-                            executeRawQuery("CREATE TABLE " +  myTable2.tableName + " (c varchar(40), b integer)", connection: connection) { result, rows in
+                            executeRawQuery("CREATE TABLE \"" +  myTable2.tableName + "\" (c varchar(40), b integer)", connection: connection) { result, rows in
                                 XCTAssertEqual(result.success, true, "CREATE TABLE failed")
                                 XCTAssertNil(result.asError, "Error in CREATE TABLE: \(result.asError!)")
                                 
-                                executeRawQuery("CREATE TABLE " +  myTable3.tableName + " (d varchar(40), b integer)", connection: connection) { result, rows in
+                                executeRawQuery("CREATE TABLE \"" +  myTable3.tableName + "\" (d varchar(40), b integer)", connection: connection) { result, rows in
                                     XCTAssertEqual(result.success, true, "CREATE TABLE failed")
                                     XCTAssertNil(result.asError, "Error in CREATE TABLE: \(result.asError!)")
                                     
@@ -193,16 +193,16 @@ class TestJoin: XCTestCase {
                     
                     cleanUp(table: myTable3.tableName, connection: connection) { result in
                         
-                        executeRawQuery("CREATE TABLE " +  myTable1.tableName + " (a varchar(40), b integer)", connection: connection) { result, rows in
+                        executeRawQuery("CREATE TABLE \"" +  myTable1.tableName + "\" (a varchar(40), b integer)", connection: connection) { result, rows in
                             
                             XCTAssertEqual(result.success, true, "CREATE TABLE failed")
                             XCTAssertNil(result.asError, "Error in CREATE TABLE: \(result.asError!)")
                             
-                            executeRawQuery("CREATE TABLE " +  myTable2.tableName + " (c varchar(40), b integer)", connection: connection) { result, rows in
+                            executeRawQuery("CREATE TABLE \"" +  myTable2.tableName + "\" (c varchar(40), b integer)", connection: connection) { result, rows in
                                 XCTAssertEqual(result.success, true, "CREATE TABLE failed")
                                 XCTAssertNil(result.asError, "Error in CREATE TABLE: \(result.asError!)")
                                 
-                                executeRawQuery("CREATE TABLE " +  myTable3.tableName + " (d varchar(40), b integer)", connection: connection) { result, rows in
+                                executeRawQuery("CREATE TABLE \"" +  myTable3.tableName + "\" (d varchar(40), b integer)", connection: connection) { result, rows in
                                     XCTAssertEqual(result.success, true, "CREATE TABLE failed")
                                     XCTAssertNil(result.asError, "Error in CREATE TABLE: \(result.asError!)")
                                     

--- a/Tests/SwiftKuerySQLiteTests/TestParameters.swift
+++ b/Tests/SwiftKuerySQLiteTests/TestParameters.swift
@@ -56,7 +56,7 @@ class TestParameters: XCTestCase {
             
             cleanUp(table: t.tableName, connection: connection) { result in
                 
-                executeRawQuery("CREATE TABLE " +  t.tableName + " (a varchar(40), b integer)", connection: connection) { result, rows in
+                executeRawQuery("CREATE TABLE \"" +  t.tableName + "\" (a varchar(40), b integer)", connection: connection) { result, rows in
                     XCTAssertEqual(result.success, true, "CREATE TABLE failed")
                     XCTAssertNil(result.asError, "Error in CREATE TABLE: \(result.asError!)")
                     
@@ -91,7 +91,7 @@ class TestParameters: XCTestCase {
                                     XCTAssertEqual(rows![2][0]! as! String, "peach", "Wrong value in row 2 column 0")
                                     XCTAssertEqual(rows![2][1]! as! Int32, 2, "Wrong value in row 2 column 1")
                                     
-                                    let raw = "UPDATE " + t.tableName + " SET a = 'banana', b = $1 WHERE a = $2"
+                                    let raw = "UPDATE \"" + t.tableName + "\" SET a = 'banana', b = $1 WHERE a = $2"
                                     executeRawQueryWithParameters(raw, connection: connection, parameters: 4, "peach") { result, rows in
                                         XCTAssertEqual(result.success, true, "UPDATE failed")
                                         XCTAssertNil(result.asError, "Error in UPDATE: \(result.asError!)")

--- a/Tests/SwiftKuerySQLiteTests/TestSchema.swift
+++ b/Tests/SwiftKuerySQLiteTests/TestSchema.swift
@@ -39,7 +39,7 @@ class TestSchema: XCTestCase {
     
     class MyTable: Table {
         let a = Column("a", String.self, primaryKey: true, defaultValue: "qiwi", collate: "BINARY")
-        let b = Column("b", Int32.self, autoIncrement: true)
+        let b = Column("b", Int32.self)
         let c = Column("c", Double.self, defaultValue: 4.95, check: "c > 0")
         
         let tableName = "MyTable" + tableNameSuffix
@@ -47,7 +47,7 @@ class TestSchema: XCTestCase {
     
     class MyNewTable: Table {
         let a = Column("a", String.self, primaryKey: true, defaultValue: "qiwi")
-        let b = Column("b", Int32.self, autoIncrement: true)
+        let b = Column("b", Int32.self)
         let c = Column("c", Double.self, defaultValue: 4.95)
         let d = Column("d", Int32.self, defaultValue: 123)
         

--- a/Tests/SwiftKuerySQLiteTests/TestSelect.swift
+++ b/Tests/SwiftKuerySQLiteTests/TestSelect.swift
@@ -75,7 +75,7 @@ class TestSelect: XCTestCase {
             
             cleanUp(table: t.tableName, connection: connection) { result in
                 
-                executeRawQuery("CREATE TABLE " +  t.tableName + " (a varchar(40), b integer)", connection: connection) { result, rows in
+                executeRawQuery("CREATE TABLE \"" +  t.tableName + "\" (a varchar(40), b integer)", connection: connection) { result, rows in
                     XCTAssertEqual(result.success, true, "CREATE TABLE failed")
                     XCTAssertNil(result.asError, "Error in CREATE TABLE: \(result.asError!)")
                     
@@ -191,7 +191,7 @@ class TestSelect: XCTestCase {
                                                                 XCTAssertEqual(rows!.count, 2, "SELECT returned wrong number of rows: \(rows!.count) instead of 2")
                                                                 XCTAssertEqual(rows![0][0]! as! String, "apple", "Wrong value in row 0 column 0")
                                                                 
-                                                                let s9 = "Select * from \(t.tableName) where a IN ('apple', 'lalala')"
+                                                                let s9 = "Select * from \"\(t.tableName)\" where a IN ('apple', 'lalala')"
                                                                 executeRawQuery(s9, connection: connection) { result, rows in
                                                                     XCTAssertEqual(result.success, true, "SELECT failed")
                                                                     XCTAssertNotNil(result.asResultSet, "SELECT returned no rows")
@@ -239,15 +239,15 @@ class TestSelect: XCTestCase {
                 cleanUp(table: t2.tableName, connection: connection) { result in
                     cleanUp(table: t3.tableName, connection: connection) { result in
                         
-                        executeRawQuery("CREATE TABLE " +  t1.tableName + " (a varchar(40), b integer)", connection: connection) { result, rows in
+                        executeRawQuery("CREATE TABLE \"" +  t1.tableName + "\" (a varchar(40), b integer)", connection: connection) { result, rows in
                             XCTAssertEqual(result.success, true, "CREATE TABLE failed")
                             XCTAssertNil(result.asError, "Error in CREATE TABLE: \(result.asError!)")
                             
-                            executeRawQuery("CREATE TABLE " +  t2.tableName + " (c varchar(40), b integer)", connection: connection) { result, rows in
+                            executeRawQuery("CREATE TABLE \"" +  t2.tableName + "\" (c varchar(40), b integer)", connection: connection) { result, rows in
                                 XCTAssertEqual(result.success, true, "CREATE TABLE failed")
                                 XCTAssertNil(result.asError, "Error in CREATE TABLE: \(result.asError!)")
                                 
-                                executeRawQuery("CREATE TABLE " +  t3.tableName + " (d varchar(40), b integer)", connection: connection) { result, rows in
+                                executeRawQuery("CREATE TABLE \"" +  t3.tableName + "\" (d varchar(40), b integer)", connection: connection) { result, rows in
                                     XCTAssertEqual(result.success, true, "CREATE TABLE failed")
                                     XCTAssertNil(result.asError, "Error in CREATE TABLE: \(result.asError!)")
                                     
@@ -311,7 +311,7 @@ class TestSelect: XCTestCase {
             
             cleanUp(table: t.tableName, connection: connection) { result in
                 
-                executeRawQuery("CREATE TABLE " +  t.tableName + " (a varchar(40), date date, timestamp timestamp, time time)", connection: connection) { result, rows in
+                executeRawQuery("CREATE TABLE \"" +  t.tableName + "\" (a varchar(40), date date, timestamp timestamp, time time)", connection: connection) { result, rows in
                     XCTAssertEqual(result.success, true, "CREATE TABLE failed")
                     XCTAssertNil(result.asError, "Error in CREATE TABLE: \(result.asError!)")
                     

--- a/Tests/SwiftKuerySQLiteTests/TestSubquery.swift
+++ b/Tests/SwiftKuerySQLiteTests/TestSubquery.swift
@@ -51,7 +51,7 @@ class TestSubquery: XCTestCase {
             
             cleanUp(table: t.tableName, connection: connection) { result in
                 
-                executeRawQuery("CREATE TABLE " +  t.tableName + " (a varchar(40), b integer)", connection: connection) { result, rows in
+                executeRawQuery("CREATE TABLE \"" +  t.tableName + "\" (a varchar(40), b integer)", connection: connection) { result, rows in
                     XCTAssertEqual(result.success, true, "CREATE TABLE failed")
                     XCTAssertNil(result.asError, "Error in CREATE TABLE: \(result.asError!)")
                     

--- a/Tests/SwiftKuerySQLiteTests/TestTransaction.swift
+++ b/Tests/SwiftKuerySQLiteTests/TestTransaction.swift
@@ -58,7 +58,7 @@ class TestTransaction: XCTestCase {
             
             cleanUp(table: t.tableName, connection: connection) { result in
                 
-                executeRawQuery("CREATE TABLE " +  t.tableName + " (a varchar(40), b integer)", connection: connection) { result, rows in
+                executeRawQuery("CREATE TABLE \"" +  t.tableName + "\" (a varchar(40), b integer)", connection: connection) { result, rows in
                     XCTAssertEqual(result.success, true, "CREATE TABLE failed")
                     XCTAssertNil(result.asError, "Error in CREATE TABLE: \(result.asError!)")
                     
@@ -109,7 +109,7 @@ class TestTransaction: XCTestCase {
             
             cleanUp(table: t.tableName, connection: connection) { result in
                 
-                executeRawQuery("CREATE TABLE " +  t.tableName + " (a varchar(40), b integer)", connection: connection) { result, rows in
+                executeRawQuery("CREATE TABLE \"" +  t.tableName + "\" (a varchar(40), b integer)", connection: connection) { result, rows in
                     XCTAssertEqual(result.success, true, "CREATE TABLE failed")
                     XCTAssertNil(result.asError, "Error in CREATE TABLE: \(result.asError!)")
                     
@@ -163,7 +163,7 @@ class TestTransaction: XCTestCase {
                     XCTAssertEqual(result.success, true, "Failed to start transaction")
                     XCTAssertNil(result.asError, "Error in start transaction: \(result.asError!)")
                     
-                    executeRawQuery("CREATE TABLE " +  t.tableName + " (a varchar(40), b integer)", connection: connection) { result, rows in
+                    executeRawQuery("CREATE TABLE \"" +  t.tableName + "\" (a varchar(40), b integer)", connection: connection) { result, rows in
                         XCTAssertEqual(result.success, true, "CREATE TABLE failed")
                         XCTAssertNil(result.asError, "Error in CREATE TABLE: \(result.asError!)")
                         
@@ -265,7 +265,7 @@ class TestTransaction: XCTestCase {
                             connection.startTransaction() { result in
                                 XCTAssertEqual(result.success, false, "Started second transaction")
                                 
-                                executeRawQuery("CREATE TABLE " +  t.tableName + " (a varchar(40), b integer)", connection: connection) { result, rows in
+                                executeRawQuery("CREATE TABLE \"" +  t.tableName + "\" (a varchar(40), b integer)", connection: connection) { result, rows in
                                     XCTAssertEqual(result.success, true, "CREATE TABLE failed")
                                     XCTAssertNil(result.asError, "Error in CREATE TABLE: \(result.asError!)")
                                     
@@ -322,7 +322,7 @@ class TestTransaction: XCTestCase {
                             XCTAssertEqual(result.success, true, "Failed to start transaction")
                             XCTAssertNil(result.asError, "Error in start transaction: \(result.asError!)")
                             
-                            executeRawQuery("CREATE TABLE " +  t.tableName + " (a varchar(40), b integer)", connection: connection) { result, rows in
+                            executeRawQuery("CREATE TABLE \"" +  t.tableName + "\" (a varchar(40), b integer)", connection: connection) { result, rows in
                                 XCTAssertEqual(result.success, true, "CREATE TABLE failed")
                                 XCTAssertNil(result.asError, "Error in CREATE TABLE: \(result.asError!)")
                                 
@@ -377,7 +377,7 @@ class TestTransaction: XCTestCase {
                             XCTAssertEqual(result.success, true, "Failed to start transaction")
                             XCTAssertNil(result.asError, "Error in start transaction: \(result.asError!)")
                             
-                            executeRawQuery("CREATE TABLE " +  t.tableName + " (a varchar(40), b integer)", connection: connection) { result, rows in
+                            executeRawQuery("CREATE TABLE \"" +  t.tableName + "\" (a varchar(40), b integer)", connection: connection) { result, rows in
                                 XCTAssertEqual(result.success, true, "CREATE TABLE failed")
                                 XCTAssertNil(result.asError, "Error in CREATE TABLE: \(result.asError!)")
                                 

--- a/Tests/SwiftKuerySQLiteTests/TestUpdate.swift
+++ b/Tests/SwiftKuerySQLiteTests/TestUpdate.swift
@@ -53,7 +53,7 @@ class TestUpdate: XCTestCase {
             
             cleanUp(table: t.tableName, connection: connection) { result in
                 
-                executeRawQuery("CREATE TABLE " +  t.tableName + " (a varchar(40), b integer)", connection: connection) { result, rows in
+                executeRawQuery("CREATE TABLE \"" +  t.tableName + "\" (a varchar(40), b integer)", connection: connection) { result, rows in
                     XCTAssertEqual(result.success, true, "CREATE TABLE failed")
                     XCTAssertNil(result.asError, "Error in CREATE TABLE: \(result.asError!)")
                     

--- a/Tests/SwiftKuerySQLiteTests/TestWith.swift
+++ b/Tests/SwiftKuerySQLiteTests/TestWith.swift
@@ -99,12 +99,12 @@ class TestWith: XCTestCase {
                             
                             cleanUp(table: t2.tableName, connection: connection) { result in
                                 
-                                executeRawQuery("CREATE TABLE " +  t1.tableName + " (a varchar(40), b integer)", connection: connection) { result, rows in
+                                executeRawQuery("CREATE TABLE \"" +  t1.tableName + "\" (a varchar(40), b integer)", connection: connection) { result, rows in
                                     
                                     XCTAssertEqual(result.success, true, "CREATE TABLE failed")
                                     XCTAssertNil(result.asError, "Error in CREATE TABLE: \(result.asError!)")
                                     
-                                    executeRawQuery("CREATE TABLE " +  t2.tableName + " (c varchar(40), b integer)", connection: connection) { result, rows in
+                                    executeRawQuery("CREATE TABLE \"" +  t2.tableName + "\" (c varchar(40), b integer)", connection: connection) { result, rows in
                                         XCTAssertEqual(result.success, true, "CREATE TABLE failed")
                                         XCTAssertNil(result.asError, "Error in CREATE TABLE: \(result.asError!)")
                                         
@@ -138,7 +138,7 @@ class TestWith: XCTestCase {
                                                         
                                                         cleanUp(table: t3.tableName, connection: connection) { result in
                                                             
-                                                            executeRawQuery("CREATE TABLE " +  t3.tableName + " (x varchar(40), y integer)", connection: connection) { result, rows in
+                                                            executeRawQuery("CREATE TABLE \"" +  t3.tableName + "\" (x varchar(40), y integer)", connection: connection) { result, rows in
                                                                 XCTAssertEqual(result.success, true, "CREATE TABLE failed")
                                                                 XCTAssertNil(result.asError, "Error in CREATE TABLE: \(result.asError!)")
                                                                 

--- a/Tests/SwiftKuerySQLiteTests/VerifyLinuxTestCount.swift
+++ b/Tests/SwiftKuerySQLiteTests/VerifyLinuxTestCount.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-#if os(OSX)
+#if os(OSX) && swift(>=4.1)
     import XCTest
     
     class VerifyLinuxTestCount: XCTestCase {


### PR DESCRIPTION
Add createAutoIncrement function.
Append AUTOINCREMENT to match the behavior of MySQL and PostgreSQL regarding reuse of identifiers (ie, do not re-use).
Remove invalid autoincrement flags from test table columns.
Prevent failing test running on swift < 4.1.1