### PR TITLE
Add shared inMemory database support to the SQLite connection pool

### DIFF
--- a/Sources/SwiftKuerySQLite/Location.swift
+++ b/Sources/SwiftKuerySQLite/Location.swift
@@ -26,6 +26,9 @@ public enum Location {
     
     /// The URI where the database is stored.
     case uri(String)
+
+    /// In memory database that is shared across a connection pool
+    case inMemoryShared
 }
 
 extension Location: CustomStringConvertible {
@@ -38,6 +41,8 @@ extension Location: CustomStringConvertible {
             return ""
         case .uri(let uri):
             return uri
+        case .inMemoryShared:
+            return "file::memory:?cache=shared"
         }
     }
 }

--- a/Sources/SwiftKuerySQLite/SQLiteConnection.swift
+++ b/Sources/SwiftKuerySQLite/SQLiteConnection.swift
@@ -98,7 +98,7 @@ public class SQLiteConnection: Connection {
     ///
     /// - Parameter location: Describes where the database is stored.
     /// - Returns: The `ConnectionPool` of `SQLiteConnection`.
-    public static func createPool(_ location: Location = .inMemory, poolOptions: ConnectionPoolOptions) -> ConnectionPool {
+    public static func createPool(_ location: Location = .inMemoryShared, poolOptions: ConnectionPoolOptions) -> ConnectionPool {
         let connectionGenerator: () -> Connection? = {
             let connection = SQLiteConnection(location)
             if sqlite3_open(location.description, &connection.connection) != SQLITE_OK {


### PR DESCRIPTION
This PR fixes the in memory database support for SQLite when using a connection pool.

We add a new inMemoryShared location that is used when initializing the connection pool and ensures that the database is available across all threads. When the last connection to the database is closed it is released from memory so with our current implementation it will persist until the application is closed.