### PR TITLE
Build column within plugin

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,8 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", from: "2.0.0"),
+        //.package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", from: "2.0.0"),
+        .package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", .branch("issue_column_attributes") ),
     ],
     targets: [
         .target(

--- a/Tests/SwiftKuerySQLiteTests/TestSchema.swift
+++ b/Tests/SwiftKuerySQLiteTests/TestSchema.swift
@@ -34,6 +34,7 @@ class TestSchema: XCTestCase {
             ("testForeignKeys", testForeignKeys),
             ("testPrimaryKeys", testPrimaryKeys),
             ("testTypes", testTypes),
+            ("testAutoIncrement", testAutoIncrement),
         ]
     }
     
@@ -329,6 +330,61 @@ class TestSchema: XCTestCase {
                             XCTAssertEqual(rows![0][8]! as! String, "\(now)", "Wrong value in row 0 column 8")
                             XCTAssertEqual(rows![0][9]! as! String, "\(now)", "Wrong value in row 0 column 9")
                             XCTAssertEqual(rows![0][10]! as! String, "\(now)", "Wrong value in row 0 column 10")
+                        }
+                    }
+                }
+            }
+            expectation.fulfill()
+        })
+    }
+
+    class AutoIncrement1: Table {
+        let a = Column("a", String.self, primaryKey: true, defaultValue: "qiwi")
+        let b = Column("b", Int32.self, autoIncrement: true, primaryKey: true)
+
+        let tableName = "AutoIncrement1" + tableNameSuffix
+    }
+
+    class AutoIncrement2: Table {
+        let a = Column("a", String.self, primaryKey: true, defaultValue: "qiwi")
+        let b = Column("b", Int32.self, autoIncrement: true)
+
+        let tableName = "AutoIncrement2" + tableNameSuffix
+    }
+
+    class AutoIncrement3: Table {
+        let a = Column("a", String.self, primaryKey: true, defaultValue: "qiwi")
+        let b = Column("b", String.self, autoIncrement: true, primaryKey: true)
+
+        let tableName = "AutoIncrement3" + tableNameSuffix
+    }
+
+    func testAutoIncrement() {
+        let t1 = AutoIncrement1()
+        let t2 = AutoIncrement2()
+        let t3 = AutoIncrement3()
+
+        let pool = CommonUtils.sharedInstance.getConnectionPool()
+        performTest(asyncTasks: { expectation in
+
+            guard let connection = pool.getConnection() else {
+                XCTFail("Failed to get connection")
+                return
+            }
+            cleanUp(table: t1.tableName, connection: connection) { result in
+                cleanUp(table: t2.tableName, connection: connection) { result in
+                    cleanUp(table: t3.tableName, connection: connection) { result in
+
+                        t1.create(connection: connection) { result in
+                            XCTAssertEqual(result.success, false, "CREATE TABLE failed for \(t1.tableName)")
+
+                            t2.create(connection: connection) { result in
+                                XCTAssertEqual(result.success, false, "CREATE TABLE non primary key auto increment column didn't fail")
+
+                                t3.create(connection: connection) { result in
+                                    XCTAssertEqual(result.success, false, "CREATE TABLE non integer auto increment column didn't fail")
+                                }
+                            }
                         }
                     }
                 }

--- a/Tests/SwiftKuerySQLiteTests/TestSchema.swift
+++ b/Tests/SwiftKuerySQLiteTests/TestSchema.swift
@@ -339,7 +339,7 @@ class TestSchema: XCTestCase {
     }
 
     class AutoIncrement1: Table {
-        let a = Column("a", String.self, primaryKey: true, defaultValue: "qiwi")
+        let a = Column("a", String.self, defaultValue: "qiwi")
         let b = Column("b", Int32.self, autoIncrement: true, primaryKey: true)
 
         let tableName = "AutoIncrement1" + tableNameSuffix
@@ -353,7 +353,7 @@ class TestSchema: XCTestCase {
     }
 
     class AutoIncrement3: Table {
-        let a = Column("a", String.self, primaryKey: true, defaultValue: "qiwi")
+        let a = Column("a", String.self, defaultValue: "qiwi")
         let b = Column("b", String.self, autoIncrement: true, primaryKey: true)
 
         let tableName = "AutoIncrement3" + tableNameSuffix
@@ -376,7 +376,7 @@ class TestSchema: XCTestCase {
                     cleanUp(table: t3.tableName, connection: connection) { result in
 
                         t1.create(connection: connection) { result in
-                            XCTAssertEqual(result.success, false, "CREATE TABLE failed for \(t1.tableName)")
+                            XCTAssertEqual(result.success, true, "CREATE TABLE failed for \(t1.tableName)")
 
                             t2.create(connection: connection) { result in
                                 XCTAssertEqual(result.success, false, "CREATE TABLE non primary key auto increment column didn't fail")

--- a/Tests/SwiftKuerySQLiteTests/TestSchema.swift
+++ b/Tests/SwiftKuerySQLiteTests/TestSchema.swift
@@ -1,5 +1,5 @@
 /**
- Copyright IBM Corporation 2017
+ Copyright IBM Corporation 2017, 2018
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR updates the plugin to conform to the new QueryBuilder requirements and adds the logic for building a column representation for SQLite.