### PR TITLE
Add returnID support to INSERT queries in "next" branch

### DIFF
--- a/Sources/SwiftKuerySQLite/SQLiteConnection.swift
+++ b/Sources/SwiftKuerySQLite/SQLiteConnection.swift
@@ -215,9 +215,17 @@ public class SQLiteConnection: Connection {
     }
 
     private func execute(query: Query, parameters: [Any?], namedParameters: [String:Any?], onCompletion: (@escaping (QueryResult) -> ())) {
+        var wrappedOnCompletion: ((QueryResult) -> ())? = nil
+        if let insertQuery = query as? Insert, insertQuery.returnID {
+            wrappedOnCompletion = { queryResult in
+                // Note that this method appears to be more reliable than using
+                // last_insert_rowid().
+                self.execute("SELECT seq AS id FROM sqlite_sequence WHERE name = @1", parameters: [insertQuery.table.nameInQuery], onCompletion: onCompletion)
+            }
+        }
         do {
             let sqliteQuery = try query.build(queryBuilder: queryBuilder)
-            execute(sqliteQuery: sqliteQuery, parameters: parameters, namedParameters: namedParameters, onCompletion: onCompletion)
+            execute(sqliteQuery: sqliteQuery, parameters: parameters, namedParameters: namedParameters, onCompletion: wrappedOnCompletion ?? onCompletion)
         }
         catch QueryError.syntaxError(let error) {
             onCompletion(.error(QueryError.syntaxError(error)))


### PR DESCRIPTION
We have autoincrement working in the "next" branch. Let's complete the functionality by getting returnID working. Here's the code, along with tests, actually unmodified from my previous attempt at this.