### PR TITLE
Build against Swift 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,11 @@ matrix:
       dist: trusty
       sudo: required
       services: docker
+      env: DOCKER_IMAGE=ubuntu:16.04 DOCKER_PACKAGES="libsqlite3-dev" SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
+    - os: linux
+      dist: trusty
+      sudo: required
+      services: docker
       env: DOCKER_IMAGE=ubuntu:18.04 DOCKER_PACKAGES="libsqlite3-dev"
     - os: osx
       osx_image: xcode9.2
@@ -44,6 +49,10 @@ matrix:
     - os: osx
       osx_image: xcode10
       sudo: required
+    - os: osx
+      osx_image: xcode10.1
+      sudo: required
+      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
 
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git


### PR DESCRIPTION
Adds testing with a Swift 5 development snapshot. The snapshot is defined in Travis as `SWIFT_DEVELOPMENT_SNAPSHOT` consistently across the IBM-Swift repos, to enable us to automate updating the version.