### PR TITLE
remove timeout from connection pool options

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", .branch("issue_remove_timeout")),
+        .package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", .branch("next")),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", .branch("next")),
+        .package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", .branch("issue_remove_timeout")),
     ],
     targets: [
         .target(

--- a/Tests/SwiftKuerySQLiteTests/CommonUtils.swift
+++ b/Tests/SwiftKuerySQLiteTests/CommonUtils.swift
@@ -165,7 +165,7 @@ class CommonUtils {
             return pool
         }
         
-        pool = SQLiteConnection.createPool(filename: "testDb.db", poolOptions: ConnectionPoolOptions(initialCapacity: 1, maxCapacity: 1, timeout: 10000))
+        pool = SQLiteConnection.createPool(filename: "testDb.db", poolOptions: ConnectionPoolOptions(initialCapacity: 1, maxCapacity: 1))
         return pool!
     }
 }


### PR DESCRIPTION
This PR updates the plugin to remove the timeout passed ConnectionPoolOptions in line with the latest SwiftKuery changes.