### PR TITLE
Enhance support for nil values

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,8 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", from: "3.0.0"),
+        //.package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", from: "3.0.0"),
+        .package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", .branch("insert_nulls_property")),
     ],
     targets: [
         .target(

--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -28,7 +28,8 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", from: "3.0.0"),
+        //.package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", from: "3.0.0"),
+        .package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", .branch("insert_nulls_property")),
     ],
     targets: [
         .target(

--- a/Sources/SwiftKuerySQLite/SQLiteConnection.swift
+++ b/Sources/SwiftKuerySQLite/SQLiteConnection.swift
@@ -534,14 +534,8 @@ class SQLiteColumnBuilder: ColumnCreator {
         if column.isUnique {
             result += " UNIQUE"
         }
-        if let defaultValue = column.defaultValue {
-            var packedType: String
-            do {
-                packedType = try packType(defaultValue, queryBuilder: queryBuilder)
-            } catch {
-                return nil
-            }
-            result += " DEFAULT " + packedType
+        if let defaultValue = getDefaultValue(for: column, queryBuilder: queryBuilder) {
+            result += " DEFAULT " + defaultValue
         }
         if let checkExpression = column.checkExpression {
             result += checkExpression.contains(column.name) ? " CHECK (" + checkExpression.replacingOccurrences(of: column.name, with: "\"\(column.name)\"") + ")" : " CHECK (" + checkExpression + ")"
@@ -550,25 +544,6 @@ class SQLiteColumnBuilder: ColumnCreator {
             result += " COLLATE \"" + collate + "\""
         }
         return result
-    }
-
-    func packType(_ item: Any, queryBuilder: QueryBuilder) throws -> String {
-        switch item {
-        case let val as String:
-            return "'\(val)'"
-        case let val as Bool:
-            return val ? queryBuilder.substitutions[QueryBuilder.QuerySubstitutionNames.booleanTrue.rawValue]
-                : queryBuilder.substitutions[QueryBuilder.QuerySubstitutionNames.booleanFalse.rawValue]
-        case let val as Parameter:
-            return try val.build(queryBuilder: queryBuilder)
-        case let value as Date:
-            if let dateFormatter = queryBuilder.dateFormatter {
-                return dateFormatter.string(from: value)
-            }
-            return "'\(String(describing: value))'"
-        default:
-            return String(describing: item)
-        }
     }
 
     func isInvalidIntegerType(_ typeString: String, _ queryBuilder: QueryBuilder) -> Bool {

--- a/Sources/SwiftKuerySQLite/SQLiteConnection.swift
+++ b/Sources/SwiftKuerySQLite/SQLiteConnection.swift
@@ -1,5 +1,5 @@
 /**
- Copyright IBM Corporation 2016, 2017, 2018
+ Copyright IBM Corporation 2016, 2017, 2018, 2019
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/Tests/SwiftKuerySQLiteTests/TestInsert.swift
+++ b/Tests/SwiftKuerySQLiteTests/TestInsert.swift
@@ -1,5 +1,5 @@
 /**
- Copyright IBM Corporation 2016, 2017
+ Copyright IBM Corporation 2016, 2017, 2018, 2019
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/Tests/SwiftKuerySQLiteTests/TestSchema.swift
+++ b/Tests/SwiftKuerySQLiteTests/TestSchema.swift
@@ -1,5 +1,5 @@
 /**
- Copyright IBM Corporation 2017, 2018
+ Copyright IBM Corporation 2017, 2018, 2019
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/Tests/SwiftKuerySQLiteTests/TestSchema.swift
+++ b/Tests/SwiftKuerySQLiteTests/TestSchema.swift
@@ -36,6 +36,7 @@ class TestSchema: XCTestCase {
             ("testTypes", testTypes),
             ("testAutoIncrement", testAutoIncrement),
             ("testInt64", testInt64),
+            ("testCreateTableNilDefault", testCreateTableNilDefault),
         ]
     }
     
@@ -475,6 +476,51 @@ class TestSchema: XCTestCase {
 
                                     expectation.fulfill()
                                 }
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    }
+
+    class MyNilDefaultTable: Table {
+        let a = Column("a", String.self, defaultValue: nil, nullDefaultValue: true)
+        let b = Column("b", Int64.self, autoIncrement: true, primaryKey: true)
+        let c = Column("c", Int64.self)
+
+        let tableName = "MyNilDefaultTable" + tableNameSuffix
+    }
+
+    func testCreateTableNilDefault() {
+        let t = MyNilDefaultTable()
+
+        let pool = CommonUtils.sharedInstance.getConnectionPool()
+        performTest(asyncTasks: { expectation in
+
+            pool.getConnection { connection, error in
+                guard let connection = connection else {
+                    XCTFail("Failed to get connection")
+                    return
+                }
+                cleanUp(table: t.tableName, connection: connection) { _ in
+                    t.create(connection: connection) { result in
+                        if let error = result.asError {
+                            XCTFail("Error in CREATE TABLE: \(error)")
+                            return
+                        }
+
+                        let insert = Insert(into: t, columns: [t.c], values: [5])
+                        executeQuery(query: insert, connection: connection) { result, rows in
+                            XCTAssertNil(result.asError, "Error in INSERT")
+
+                            let select = Select(from: t)
+                            executeQuery(query: select, connection: connection) { result, rows in
+                                XCTAssertNil(result.asError, "Error on SELECT")
+                                XCTAssertNotNil(rows, "Expected rows but none returned")
+                                XCTAssertNil(rows?[0][0], "Non nil default value stored, expecting nil but returned \(String(describing: rows?[0][0]))")
+
+                                expectation.fulfill()
                             }
                         }
                     }

--- a/Tests/SwiftKuerySQLiteTests/TestUpdate.swift
+++ b/Tests/SwiftKuerySQLiteTests/TestUpdate.swift
@@ -30,6 +30,7 @@ class TestUpdate: XCTestCase {
     static var allTests: [(String, (TestUpdate) -> () throws -> Void)] {
         return [
             ("testUpdateAndDelete", testUpdateAndDelete),
+            ("testUpdateNilValue", testUpdateNilValue),
         ]
     }
     
@@ -109,6 +110,51 @@ class TestUpdate: XCTestCase {
                                             }
                                         }
                                     }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    }
+
+    func testUpdateNilValue() {
+        let t = MyTable()
+
+        let pool = CommonUtils.sharedInstance.getConnectionPool()
+        performTest(asyncTasks: { expectation in
+
+            pool.getConnection { connection, error in
+                guard let connection = connection else {
+                    XCTFail("Failed to get connection")
+                    return
+                }
+                cleanUp(table: t.tableName, connection: connection) { _ in
+
+                    executeRawQuery("CREATE TABLE \"" +  t.tableName + "\" (a varchar(40), b integer)", connection: connection) { result, rows in
+                        XCTAssertEqual(result.success, true, "CREATE TABLE failed")
+                        XCTAssertNil(result.asError, "Error in CREATE TABLE: \(result.asError!)")
+
+                        let insert = Insert(into: t, rows: [["apple", 10], ["apricot", 3], ["banana", 17], ["apple", 17], ["banana", -7], ["banana", 27]])
+                        executeQuery(query: insert, connection: connection) { result, rows in
+                            XCTAssertEqual(result.success, true, "INSERT failed")
+                            XCTAssertNil(result.asError, "Error in INSERT: \(result.asError!)")
+
+                            let update = Update(t, set:[(t.a, nil)], where: t.a == "apple")
+                            executeQuery(query: update, connection: connection) { result, rows in
+                                XCTAssertEqual(result.success, true, "UPDATE failed")
+                                XCTAssertNil(result.asError, "Error in UPDATE: \(result.asError!)")
+
+                                let select = Select(from: t)
+                                executeQuery(query: select, connection: connection) { result, rows in
+                                    XCTAssertEqual(result.success, true, "SELECT failed")
+                                    XCTAssertNil(result.asError, "Error in SELECT: \(result.asError!)")
+                                    XCTAssertNotNil(rows, "Expected rows but none returned")
+                                    for row in rows! {
+                                        XCTAssertNotEqual(row[0] as? String, "apple", "Row returned with \"apple\" instead of expected value \"nil\"")
+                                    }
+                                    expectation.fulfill()
                                 }
                             }
                         }

--- a/Tests/SwiftKuerySQLiteTests/TestUpdate.swift
+++ b/Tests/SwiftKuerySQLiteTests/TestUpdate.swift
@@ -1,5 +1,5 @@
 /**
- Copyright IBM Corporation 2016, 2017
+ Copyright IBM Corporation 2016, 2017, 2018, 2019
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR adds support for using nil to represent NULL for default column values.

The PR also adds test for inset, update and table creation when using nil values.